### PR TITLE
fix: rate limiting

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -64,6 +64,10 @@ func getClientIPFromRequest(w http.ResponseWriter, r *http.Request) string {
 	if remoteIP != "" {
 		return remoteIP
 	}
+	remoteIP = r.Header.Get("CF-Connecting-IP")
+	if remoteIP != "" {
+		return remoteIP
+	}
 	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		remoteIP = r.RemoteAddr

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -1,18 +1,14 @@
 package server
 
 import (
-	"errors"
 	"fmt"
-	"net"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/jellydator/ttlcache/v2"
 	"github.com/kataras/hcaptcha"
 	log "github.com/sirupsen/logrus"
-	"github.com/urfave/negroni"
 )
 
 type Limiter struct {
@@ -33,42 +29,26 @@ func NewLimiter(proxyCount int, ttl time.Duration) *Limiter {
 }
 
 func (l *Limiter) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	address, err := readAddress(r)
-	if err != nil {
-		var mr *malformedRequest
-		if errors.As(err, &mr) {
-			renderJSON(w, claimResponse{Message: mr.message}, mr.status)
-		} else {
-			renderJSON(w, claimResponse{Message: http.StatusText(http.StatusInternalServerError)}, http.StatusInternalServerError)
-		}
-		return
-	}
-
 	if l.ttl <= 0 {
 		next.ServeHTTP(w, r)
 		return
 	}
 
-	clintIP := getClientIPFromRequest(l.proxyCount, r)
+	clintIP := getClientIPFromRequest(w, r)
+	if clintIP == "" {
+		return
+	}
 	l.mutex.Lock()
-	if l.limitByKey(w, address) || l.limitByKey(w, clintIP) {
+	if l.limitByKey(w, clintIP) {
 		l.mutex.Unlock()
 		return
 	}
-	l.cache.SetWithTTL(address, true, l.ttl)
 	l.cache.SetWithTTL(clintIP, true, l.ttl)
 	l.mutex.Unlock()
-
-	next.ServeHTTP(w, r)
-	if w.(negroni.ResponseWriter).Status() != http.StatusOK {
-		l.cache.Remove(address)
-		l.cache.Remove(clintIP)
-		return
-	}
 	log.WithFields(log.Fields{
-		"address":  address,
 		"clientIP": clintIP,
 	}).Info("Maximum request limit has been reached")
+	next.ServeHTTP(w, r)
 }
 
 func (l *Limiter) limitByKey(w http.ResponseWriter, key string) bool {
@@ -80,28 +60,14 @@ func (l *Limiter) limitByKey(w http.ResponseWriter, key string) bool {
 	return false
 }
 
-func getClientIPFromRequest(proxyCount int, r *http.Request) string {
-	if proxyCount > 0 {
-		xForwardedFor := r.Header.Get("X-Forwarded-For")
-		if xForwardedFor != "" {
-			xForwardedForParts := strings.Split(xForwardedFor, ",")
-			// Avoid reading the user's forged request header by configuring the count of reverse proxies
-			partIndex := len(xForwardedForParts) - proxyCount
-			if partIndex < 0 {
-				partIndex = 0
-			}
-			return strings.TrimSpace(xForwardedForParts[partIndex])
-		}
-	}
-	//get the client IP address from the request
+func getClientIPFromRequest(w http.ResponseWriter, r *http.Request) string {
 	remoteIP := r.Header.Get("X-Real-IP")
 	if remoteIP != "" {
 		return remoteIP
 	}
-
-	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		remoteIP = r.RemoteAddr
+	if remoteIP == "" {
+		errMsg := "The client address is missing"
+		renderJSON(w, claimResponse{Message: errMsg}, http.StatusInternalServerError)
 	}
 	return remoteIP
 }

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -93,6 +93,11 @@ func getClientIPFromRequest(proxyCount int, r *http.Request) string {
 			return strings.TrimSpace(xForwardedForParts[partIndex])
 		}
 	}
+	//get the client IP address from the request
+	remoteIP := r.Header.Get("X-Real-IP")
+	if remoteIP != "" {
+		return remoteIP
+	}
 
 	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -62,6 +63,10 @@ func getClientIPFromRequest(w http.ResponseWriter, r *http.Request) string {
 	remoteIP := r.Header.Get("X-Real-IP")
 	if remoteIP != "" {
 		return remoteIP
+	}
+	remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		remoteIP = r.RemoteAddr
 	}
 	if remoteIP == "" {
 		errMsg := "The client address is missing"

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -12,19 +12,17 @@ import (
 )
 
 type Limiter struct {
-	mutex      sync.Mutex
-	cache      *ttlcache.Cache
-	proxyCount int
-	ttl        time.Duration
+	mutex sync.Mutex
+	cache *ttlcache.Cache
+	ttl   time.Duration
 }
 
-func NewLimiter(proxyCount int, ttl time.Duration) *Limiter {
+func NewLimiter(ttl time.Duration) *Limiter {
 	cache := ttlcache.NewCache()
 	cache.SkipTTLExtensionOnHit(true)
 	return &Limiter{
-		cache:      cache,
-		proxyCount: proxyCount,
-		ttl:        ttl,
+		cache: cache,
+		ttl:   ttl,
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,7 +29,7 @@ func NewServer(builder chain.TxBuilder, cfg *Config) *Server {
 func (s *Server) setupRouter() *http.ServeMux {
 	router := http.NewServeMux()
 	router.Handle("/", http.FileServer(web.Dist()))
-	limiter := NewLimiter(s.cfg.proxyCount, time.Duration(s.cfg.interval)*time.Minute)
+	limiter := NewLimiter(time.Duration(s.cfg.interval) * time.Minute)
 	hcaptcha := NewCaptcha(s.cfg.hcaptchaSiteKey, s.cfg.hcaptchaSecret)
 	router.Handle("/api/claim", negroni.New(limiter, hcaptcha, negroni.Wrap(s.handleClaim())))
 	router.Handle("/api/info", s.handleInfo())


### PR DESCRIPTION
This will fix rate limiting of client address. But we need to add some headers to the server.

results logs 

![image](https://github.com/user-attachments/assets/4c3ed501-fcea-412e-8c9c-00d4aab5022b)


[test case]

Note: You can use my test server (https://ethfunnel.bonmercado.top/) or setup your own environment 
1. Open the faucet home page using 2 different client (You can use vpn for the other client if you are in the same device)
2. Request coin in your wallet address for both until rate limited.

The expected result will be  different rate limited time for different client

![image](https://github.com/user-attachments/assets/ee101400-6b0d-4644-a74d-5b9324b1f62e)

